### PR TITLE
fix(demo): add disclaimer about GitButler in footer

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -57,6 +57,7 @@
 
   <footer>
     <p>&copy; 2025 MySite. All rights reserved.</p>
+    <p>Demo not powered by GitButler</p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
Add a new paragraph in the footer of demo.html to clarify that the
demo is not powered by GitButler. This improves transparency and
prevents potential confusion for users regarding the demo's origin.