### PR TITLE
feat(demo): add link to GitButler homepage in header

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -33,6 +33,7 @@
 <body>
   <header>
     <h1>Welcome to the GitButler Demo</h1>
+    <h2><a href="https://gitbutler.io">Learn more about GitButler ></a></h2>
   </header>
 
   <section>


### PR DESCRIPTION
Include a new subheading with a link to the official GitButler
website in the demo page header. This change improves user
navigation by providing quick access to more information about
GitButler directly from the demo.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4 
- <kbd>&nbsp;2&nbsp;</kbd> #5 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #3 
<!-- GitButler Footer Boundary Bottom -->

